### PR TITLE
Sniff more scripts

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,7 @@ have () {
 }
 
 find_scripts () {
-  find . -perm -u=x -type f | grep --invert-match '\.git'
+  find . -type f \( -name '*.sh' -o -perm -u=x \) | grep --invert-match '\.git'
 }
 
 if ! have shellcheck && have brew

--- a/test/03-capital-test.sh
+++ b/test/03-capital-test.sh
@@ -6,21 +6,21 @@ msg_dir=$PWD/test/messages
 error_message='Capitalize the subject line'
 
 it_passes_empty() {
-  output="$($rule $msg_dir/empty.msg)"
+  output="$($rule "$msg_dir/empty.msg")"
   test -z "$output"
 }
 
 it_passes_blank() {
-  output="$($rule $msg_dir/blank.msg)"
+  output="$($rule "$msg_dir/blank.msg")"
   test -z "$output"
 }
 
 it_passes_perfect() {
-  output="$($rule $msg_dir/perfect.msg)"
+  output="$($rule "$msg_dir/perfect.msg")"
   test -z "$output"
 }
 
 it_fails_lower_case() {
-  output="$(! $rule $msg_dir/lower-case.msg)"
+  output="$(! $rule "$msg_dir/lower-case.msg")"
   test "$error_message" == "$output"
 }


### PR DESCRIPTION
The test scripts are `sh` scripts but not executable as they are run through roundup. This PR ensures they are sniffed